### PR TITLE
chore: pin pnpm to 11.1.0 + 7-day minimumReleaseAge

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,14 @@
   "engines": {
     "node": ">=22.18.0",
     "npm": "use pnpm",
-    "pnpm": ">=9",
+    "pnpm": ">=11",
     "yarn": "use pnpm"
   },
-  "packageManager": "pnpm@10.14.0"
+  "packageManager": "pnpm@11.1.0",
+  "pnpm": {
+    "minimumReleaseAge": 10080,
+    "minimumReleaseAgeExclude": [
+      "@openzeppelin/*"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Pins `packageManager: pnpm@11.1.0` (latest)
- Adds `engines.pnpm: ">=11"`
- Adds `pnpm.minimumReleaseAge: 10080` (= 7 days, in minutes)
- Adds `pnpm.minimumReleaseAgeExclude: ["@openzeppelin/*"]`

## Why

Supply-chain hardening response to the recent npm ecosystem incidents. `minimumReleaseAge` prevents pnpm from installing any package version published less than 7 days ago, giving compromised releases time to be detected and yanked before they land in our installs.

First-party `@openzeppelin/*` packages are excluded so internal releases continue to install immediately.

## Test plan

- [ ] CI passes with the new lockfile
- [ ] `pnpm install` works locally on a fresh clone
- [ ] No transitive resolution drift introduced by the pnpm 10 → 11 bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum pnpm version requirement to 11.x and bumped package manager to pnpm 11.1.0.
  * Added package dependency release age configuration to support build consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/relayer-plugin-channels/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->